### PR TITLE
Update tools.go

### DIFF
--- a/tools/tools.go
+++ b/tools/tools.go
@@ -1,6 +1,7 @@
 package tools
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/signal"
@@ -26,21 +27,40 @@ var (
 //
 // Upon receiving a signal, the given sessions are gracefully disconnected.
 func InterceptSignal(signals []os.Signal, sessions ...*disgo.Session) error {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	signalChannel := make(chan os.Signal, 1)
 
 	// set the syscalls that signalChannel is sent.
 	signal.Notify(signalChannel, signals...)
+	defer signal.Stop(signalChannel)
+	defer close(signalChannel)
 
 	// block the calling goroutine until a signal is received.
-	<-signalChannel
+	select {
+	case <-signalChannel:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 
 	disgo.Logger.Info().Msg("Closing sessions due to signal...")
 
-	eg := errgroup.Group{}
-	for _, session := range sessions {
-		s := session
+	eg, egCtx := errgroup.WithContext(ctx)
 
+	for _, session := range sessions {
+		if session == nil {
+			continue
+		}
+
+		s := session
 		eg.Go(func() error {
+			select {
+			case <-egCtx.Done():
+				return egCtx.Err()
+			default:
+			}
+
 			if err := s.Disconnect(); err != nil {
 				err = fmt.Errorf("error closing connection to Discord Gateway: %w", err)
 				disgo.LogSession(disgo.Logger.Error(), s.ID).Err(err).Msg("")
@@ -54,7 +74,6 @@ func InterceptSignal(signals []os.Signal, sessions ...*disgo.Session) error {
 
 	if err := eg.Wait(); err != nil {
 		disgo.Logger.Warn().Msg("Not all sessions were closed successfully.")
-
 		return fmt.Errorf("error during signal intercept for termination: %w", err)
 	}
 


### PR DESCRIPTION
1️⃣ Added context
ctx, cancel := context.WithCancel(context.Background())
defer cancel()

This allows controlled cancellation of goroutines via errgroup.WithContext.

2️⃣ Replaced errgroup.Group{} with errgroup.WithContext

Instead of:

eg := errgroup.Group{}

I changed it to:

eg, egCtx := errgroup.WithContext(ctx)

Now, if one goroutine returns an error, the others receive cancellation through egCtx.

3️⃣ Added proper signal cleanup
defer signal.Stop(signalChannel)
defer close(signalChannel)

This prevents potential goroutine leaks and properly unregisters the signal handler.

4️⃣ Replaced direct blocking with select

Instead of:

<-signalChannel

I changed it to:

select {
case <-signalChannel:
case <-ctx.Done():
    return ctx.Err()
}

This allows the function to exit if the context is cancelled.

5️⃣ Added nil session protection
if session == nil {
    continue
}

Prevents a possible panic if a nil session is passed.

6️⃣ Added context cancellation check inside goroutines
select {
case <-egCtx.Done():
    return egCtx.Err()
default:
}

Prevents unnecessary work if another goroutine already failed.